### PR TITLE
Add Render Blueprint & Preview-Env workflow

### DIFF
--- a/.github/workflows/render-preview.yml
+++ b/.github/workflows/render-preview.yml
@@ -1,0 +1,15 @@
+name: Render Preview Environment
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to Render
+        uses: render-examples/preview-envs-action@v1
+        with:
+          api-key: ${{ secrets.RENDER_API_KEY }}
+          wait-for-success: true

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,45 @@
+services:
+  - type: compose
+    name: onyx-preview
+    env: docker
+    dockerfilePath: ./deployment/docker_compose/docker-compose.railway.yml
+    plan: standard-16
+    envVars:
+      # Database
+      - key: PGDATABASE
+        generateValue: true
+      - key: PGUSER
+        generateValue: true
+      - key: PGPASSWORD
+        generateValue: true
+      - key: PGHOST
+        value: db
+      - key: PGPORT
+        value: 5432
+      
+      # Redis
+      - key: REDISAUTH
+        generateValue: true
+      - key: REDISHOST
+        value: redis
+      - key: REDISPORT
+        value: 6379
+      
+      # Auth token
+      - key: INTERNAL_AUTH_TOKEN
+        generateValue: true
+      
+      # Railway compatibility
+      - key: RAILWAY_PUBLIC_DOMAIN
+        fromService:
+          type: compose
+          name: onyx-preview
+          property: hostport
+    previewsEnabled: true
+    pullRequestPreviewsEnabled: true
+    autoDeploy: false
+
+# Ensure port 80 is exposed publicly
+ports:
+  - port: 80
+    protocol: tcp


### PR DESCRIPTION
## Summary
- Add Render Blueprint configuration for PR preview environments
- Configure GitHub Actions workflow to automatically deploy preview environments
- Use docker-compose.railway.yml as the base configuration

## Changes
1. **render.yaml** - Render Blueprint configuration
   - Uses compose deployment type
   - Points to existing docker-compose.railway.yml
   - Configures standard-16 plan (16GB RAM, 4 vCPU)
   - Exposes port 80 publicly for nginx proxy
   - Auto-generates required environment variables

2. **.github/workflows/render-preview.yml** - GitHub Actions workflow
   - Triggers on PR opened, reopened, and synchronize events
   - Uses render-examples/preview-envs-action@v1
   - Requires RENDER_API_KEY secret

## Services Deployed
Based on docker-compose.railway.yml analysis:
- **nginx** (port 80) - Main entry point, reverse proxy
- **api_server** (port 8080) - FastAPI backend
- **web_server** (port 3000) - Next.js frontend  
- **background** - Celery worker
- **model_server** (port 8000) - ML model server
- **vespa** (ports 8080, 19100) - Search engine
- **db** (port 5432) - PostgreSQL
- **redis** (port 6379) - Cache/queue

## Next Steps
1. **Add RENDER_API_KEY secret** to repository settings:
   - Go to Settings → Secrets and variables → Actions
   - Add new repository secret named `RENDER_API_KEY`
   - Get API key from Render dashboard: https://dashboard.render.com/account/api-keys

2. **Connect to Render**:
   - Visit https://dashboard.render.com
   - Create new Blueprint instance from this repo
   - Select the `feat/render-previews` branch initially

3. **Test Preview Environment**:
   - Once this PR is merged, all future PRs will automatically get preview environments
   - Preview URL will be posted as a comment on each PR

🤖 Generated with [Claude Code](https://claude.ai/code)